### PR TITLE
Flexible extraction of bounds variable names

### DIFF
--- a/pcmdi_utils/land_sea_mask.py
+++ b/pcmdi_utils/land_sea_mask.py
@@ -44,6 +44,7 @@ def generate_land_sea_mask(ds, tool="pcmdi", maskname="lsmask"):
     return mask
 
 
+# flake8: noqa: C901
 def generate_land_sea_mask__pcmdi(
     target_grid,
     source=None,
@@ -125,16 +126,26 @@ def generate_land_sea_mask__pcmdi(
             )
 
         # Add missed information during the regrid process
-        # (this might be a bug... will report it to xcdat repo later)
-        ds_regrid[data_var].lat.attrs["axis"] = "Y"
-        ds_regrid[data_var].lon.attrs["axis"] = "X"
-        ds_regrid[data_var].lat.attrs["bounds"] = "lat_bnds"
-        ds_regrid[data_var].lon.attrs["bounds"] = "lon_bnds"
-        ds_regrid[data_var].lat.attrs["units"] = "degrees_north"
+        # (this might be a bug... will report it to xcdat team later)
+        if "axis" not in ds_regrid[data_var].lat.attrs.keys():
+            ds_regrid[data_var].lat.attrs["axis"] = "Y"
+        if "axis" not in ds_regrid[data_var].lon.attrs.keys():
+            ds_regrid[data_var].lon.attrs["axis"] = "X"
+        if "bounds" not in ds_regrid[data_var].lat.attrs.keys():
+            ds_regrid[data_var].lat.attrs["bounds"] = "lat_bnds"
+        if "bounds" not in ds_regrid[data_var].lon.attrs.keys():
+            ds_regrid[data_var].lon.attrs["bounds"] = "lon_bnds"
+        if "units" not in ds_regrid[data_var].lat.attrs:
+            ds_regrid[data_var].lat.attrs["units"] = "degrees_north"
 
     # re-generate lat lon bounds (original bounds are 2d arrays where 1d array for each is expected)
     ds_regrid = (
-        ds_regrid.drop_vars(["lat_bnds", "lon_bnds"])
+        ds_regrid.drop_vars(
+            [
+                ds_regrid[data_var].lat.attrs["bounds"],
+                ds_regrid[data_var].lon.attrs["bounds"],
+            ]
+        )
         .bounds.add_bounds("Y")
         .bounds.add_bounds("X")
     )


### PR DESCRIPTION
## Description
Variable names for lat/lon bounds were hard-coded, causing issue when it is different in loaded dataset. This PR will make extraction of bounds variable names in flexible way.

- Closes #11 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
